### PR TITLE
Make proper screenshots for underlying scrollable views

### DIFF
--- a/RNGridMenu.m
+++ b/RNGridMenu.m
@@ -47,6 +47,22 @@ CGPoint RNCentroidOfTouchesInView(NSSet *touches, UIView *view) {
     return image;
 }
 
+- (UIImage *)rn_screenshotForScrollViewWithContentOffset:(CGPoint)contentOffset {
+    UIGraphicsBeginImageContext(self.bounds.size);
+    //need to translate the context down to the current visible portion of the scrollview
+    CGContextTranslateCTM(UIGraphicsGetCurrentContext(), 0, -contentOffset.y);
+    [self.layer renderInContext:UIGraphicsGetCurrentContext()];
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    
+    // helps w/ our colors when blurring
+    // feel free to adjust jpeg quality (lower = higher perf)
+    NSData *imageData = UIImageJPEGRepresentation(image, 0.55);
+    image = [UIImage imageWithData:imageData];
+    
+    return image;
+}
+
 @end
 
 
@@ -546,7 +562,9 @@ static RNGridMenu *rn_visibleGridMenu;
         self.blurView.alpha = 0.f;
 
         self.menuView.alpha = 0.f;
-        UIImage *screenshot = [self.parentViewController.view rn_screenshot];
+        UIImage *screenshot = ([self.parentViewController.view isKindOfClass:[UIScrollView class]] ?
+                               [self.parentViewController.view rn_screenshotForScrollViewWithContentOffset:[(UIScrollView *)self.parentViewController.view contentOffset]] :
+                               [self.parentViewController.view rn_screenshot]);        
         self.menuView.alpha = 1.f;
         self.blurView.alpha = 1.f;
         self.blurView.layer.contents = (id)screenshot.CGImage;


### PR DESCRIPTION
When showing menu above UITableView (or other scrollable view) screenshot is rendered incorrectly if table is scrolled down from the top.
![rngridmenuscreenshot](https://f.cloud.github.com/assets/2015453/858082/a88c093e-f55e-11e2-8c20-3dda434f7ffe.png)

For such case we need to make screenshot based on current table content offset. Added such ability.
