### PR TITLE
Fixing compiler warnings

### DIFF
--- a/RNGridMenu.m
+++ b/RNGridMenu.m
@@ -92,7 +92,7 @@ CGPoint RNCentroidOfTouchesInView(NSSet *touches, UIView *view) {
 
         // create grayscale image to mask context
         CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceGray();
-        CGContextRef context = CGBitmapContextCreate(nil, maskLayer.bounds.size.width, maskLayer.bounds.size.height, 8, 0, colorSpace, kCGImageAlphaNone);
+        CGContextRef context = CGBitmapContextCreate(nil, maskLayer.bounds.size.width, maskLayer.bounds.size.height, 8, 0, colorSpace, (CGBitmapInfo)kCGImageAlphaNone);
         CGContextTranslateCTM(context, 0, maskLayer.bounds.size.height);
         CGContextScaleCTM(context, 1.f, -1.f);
         [maskLayer renderInContext:context];
@@ -157,7 +157,7 @@ CGPoint RNCentroidOfTouchesInView(NSSet *touches, UIView *view) {
                                              8,
                                              outBuffer.rowBytes,
                                              colorSpace,
-                                             kCGImageAlphaNoneSkipLast);
+                                             (CGBitmapInfo)kCGImageAlphaNoneSkipLast);
     CGImageRef imageRef = CGBitmapContextCreateImage(ctx);
     UIImage *returnImage = [UIImage imageWithCGImage:imageRef];
 


### PR DESCRIPTION
After upgrading to Xcode 5 and iOS 7.0 SDK, I got a compiler warning on line 95 and 160. Had to cast to (CGBitmapInfo) for the warning to go away.
