### PR TITLE
Removed warning of unused variable (offset)

### DIFF
--- a/RNGridMenu.m
+++ b/RNGridMenu.m
@@ -545,7 +545,6 @@ static RNGridMenu *rn_visibleGridMenu;
         NSInteger rowLength = ceilf(itemCount / (CGFloat)rowCount);
         NSInteger rowStartIndex = i * rowLength;
 
-        NSInteger offset = 0;
         if ((i + 1) * rowLength > itemCount) {
             rowLength = itemCount - i * rowLength;
         }


### PR DESCRIPTION
`RNGridMenu`'s method `-(void)layoutAsGrid` had an unused variable (`NSInteger offset = 0`) that was not used in the method. This causes a warning under many configurations.
