### PR TITLE
If blur level is set to 0, then still call completion block.

### DIFF
--- a/RNGridMenu.m
+++ b/RNGridMenu.m
@@ -590,6 +590,8 @@ static RNGridMenu *rn_visibleGridMenu;
                 [self.view layoutIfNeeded];
             });
         });
+    } else {
+      if (screenshotCompletion) screenshotCompletion();
     }
 }
 


### PR DESCRIPTION
If the blur is set to 0, the menu appears without animating. This fixes that by calling the completion block even if the blur level is 0.
